### PR TITLE
Fix .NET tests with Unity Assert compatibility layer

### DIFF
--- a/.NET/Benchmark/Benchmark.csproj
+++ b/.NET/Benchmark/Benchmark.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
+      <PackageReference Include="BenchmarkDotNet" Version="0.15.2" />
     </ItemGroup>
 
 </Project>

--- a/.NET/Test/Test.csproj
+++ b/.NET/Test/Test.csproj
@@ -9,10 +9,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
-        <PackageReference Include="NUnit" Version="3.13.3" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-        <PackageReference Include="coverlet.collector" Version="6.0.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+        <PackageReference Include="NUnit" Version="4.4.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />
+        <PackageReference Include="coverlet.collector" Version="6.0.4">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/Assets/Tests/AssertCompatibility.cs
+++ b/Assets/Tests/AssertCompatibility.cs
@@ -1,0 +1,109 @@
+#if !UNITY_5_3_OR_NEWER
+using NUnit.Framework;
+
+namespace OneShot.Test
+{
+    public static class Assert
+    {
+        public static void AreSame(object expected, object actual)
+        {
+            NUnit.Framework.Assert.That(actual, Is.SameAs(expected));
+        }
+
+        public static void AreSame(object expected, object actual, string message)
+        {
+            NUnit.Framework.Assert.That(actual, Is.SameAs(expected), message);
+        }
+
+        public static void AreNotSame(object expected, object actual)
+        {
+            NUnit.Framework.Assert.That(actual, Is.Not.SameAs(expected));
+        }
+
+        public static void AreNotSame(object expected, object actual, string message)
+        {
+            NUnit.Framework.Assert.That(actual, Is.Not.SameAs(expected), message);
+        }
+
+        public static void AreEqual<T>(T expected, T actual)
+        {
+            NUnit.Framework.Assert.That(actual, Is.EqualTo(expected));
+        }
+
+        public static void AreEqual<T>(T expected, T actual, string message)
+        {
+            NUnit.Framework.Assert.That(actual, Is.EqualTo(expected), message);
+        }
+
+        public static void IsTrue(bool condition)
+        {
+            NUnit.Framework.Assert.That(condition, Is.True);
+        }
+
+        public static void IsTrue(bool condition, string message)
+        {
+            NUnit.Framework.Assert.That(condition, Is.True, message);
+        }
+
+        public static void IsFalse(bool condition)
+        {
+            NUnit.Framework.Assert.That(condition, Is.False);
+        }
+
+        public static void IsFalse(bool condition, string message)
+        {
+            NUnit.Framework.Assert.That(condition, Is.False, message);
+        }
+
+        public static void IsNull(object value)
+        {
+            NUnit.Framework.Assert.That(value, Is.Null);
+        }
+
+        public static void IsNull(object value, string message)
+        {
+            NUnit.Framework.Assert.That(value, Is.Null, message);
+        }
+
+        public static void IsNotNull(object value)
+        {
+            NUnit.Framework.Assert.That(value, Is.Not.Null);
+        }
+
+        public static void IsNotNull(object value, string message)
+        {
+            NUnit.Framework.Assert.That(value, Is.Not.Null, message);
+        }
+
+        public static void Throws<T>(NUnit.Framework.TestDelegate code) where T : System.Exception
+        {
+            NUnit.Framework.Assert.Throws<T>(code);
+        }
+
+        public static T Catch<T>(NUnit.Framework.TestDelegate code) where T : System.Exception
+        {
+            return NUnit.Framework.Assert.Catch<T>(code);
+        }
+
+        public static void DoesNotThrow(NUnit.Framework.TestDelegate code)
+        {
+            NUnit.Framework.Assert.DoesNotThrow(code);
+        }
+
+        public static void That<T>(T actual, NUnit.Framework.Constraints.IResolveConstraint expression)
+        {
+            NUnit.Framework.Assert.That(actual, expression);
+        }
+
+        public static void That<T>(T actual, NUnit.Framework.Constraints.IResolveConstraint expression, string message)
+        {
+            NUnit.Framework.Assert.That(actual, expression, message);
+        }
+
+        public static void That(NUnit.Framework.TestDelegate code, NUnit.Framework.Constraints.IResolveConstraint expression)
+        {
+            NUnit.Framework.Assert.That(code, expression);
+        }
+    }
+}
+#endif

--- a/Assets/Tests/AssertCompatibility.cs.meta
+++ b/Assets/Tests/AssertCompatibility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a8f4c5d6e2b34f5489a3c7d8e9f0a1b2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Fixed failing .NET tests by creating a Unity Assert compatibility layer
- Updated NuGet packages to latest versions
- All 76 tests now pass successfully

## Changes
1. **Added AssertCompatibility.cs** - Provides Unity-compatible Assert methods (AreSame, AreNotSame, AreEqual, etc.) for NUnit in .NET builds
2. **Conditional compilation** - Wrapped with `#if \!UNITY_5_3_OR_NEWER` to only affect .NET builds, leaving Unity tests unchanged
3. **Updated dependencies**:
   - NUnit: 3.13.3 → 4.4.0
   - NUnit3TestAdapter: 4.5.0 → 5.1.0
   - BenchmarkDotNet: 0.13.2 → 0.15.2
   - Microsoft.NET.Test.Sdk: 17.7.1 → 17.14.1
   - coverlet.collector: 6.0.0 → 6.0.4

## Test plan
- [x] Run .NET tests: `dotnet test --no-build --verbosity normal` - All 76 tests pass
- [ ] Verify Unity tests still work in Unity Test Runner
- [ ] Ensure no compilation issues in Unity with the new AssertCompatibility.cs file

🤖 Generated with [Claude Code](https://claude.ai/code)